### PR TITLE
Inline XDebug Service Controls

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -33,6 +33,16 @@ tooling:
     service: appserver
   gulp:
     service: appserver
+  xdebug-on:
+    service: appserver
+    description: Enable xdebug
+    cmd: "docker-php-ext-enable xdebug && /etc/init.d/apache2 reload"
+    user: root
+  xdebug-off:
+    service: appserver
+    description: Disable xdebug
+    cmd: "rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && /etc/init.d/apache2 reload"
+    user: root
 env_file:
   - .lando.env
 excludes:


### PR DESCRIPTION
Adds tooling to disable and enable xdebug without having to rebuild/restart the container.  XDebug defaults to enabled.